### PR TITLE
Action server impl

### DIFF
--- a/ragnar_drivers/CMakeLists.txt
+++ b/ragnar_drivers/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED
     sensor_msgs
     industrial_utils
     ragnar_kinematics
+    actionlib
 )
 
 ## System dependencies are found with CMake's conventions
@@ -160,6 +161,12 @@ target_link_libraries(ragnar_streamer_node
   # ${PROJECT_NAME}
   ${catkin_LIBRARIES}
 )
+
+add_executable(ragnar_action_test_node
+  src/action_test_node.cpp 
+)
+
+target_link_libraries(ragnar_action_test_node ${catkin_LIBRARIES})
 
 #############
 ## Install ##

--- a/ragnar_drivers/include/ragnar_drivers/ragnar_joint_streamer.h
+++ b/ragnar_drivers/include/ragnar_drivers/ragnar_joint_streamer.h
@@ -2,6 +2,8 @@
 #define RAGNAR_JOINT_TRAJECTORY_STREAMER
 
 #include "industrial_robot_client/joint_trajectory_streamer.h"
+#include <actionlib/server/action_server.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
 
 namespace ragnar_drivers
 {
@@ -11,6 +13,8 @@ class RagnarTrajectoryStreamer
           JointTrajectoryStreamer
 {
 public:
+  RagnarTrajectoryStreamer();
+
   using JointTrajectoryInterface::init;
 
   virtual bool transform(const trajectory_msgs::JointTrajectoryPoint& pt_in,
@@ -19,6 +23,22 @@ public:
   virtual bool trajectory_to_msgs(
       const trajectory_msgs::JointTrajectoryConstPtr& traj,
       std::vector<industrial::joint_traj_pt_message::JointTrajPtMessage>* msgs);
+
+  //
+  // Action Server Interface
+  //
+
+  typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction> JointTractoryActionServer;
+
+  virtual void jointStateCB(const sensor_msgs::JointStateConstPtr &msg);
+  void goalCB(JointTractoryActionServer::GoalHandle & gh);
+  void cancelCB(JointTractoryActionServer::GoalHandle & gh);
+
+  JointTractoryActionServer action_server_;
+  JointTractoryActionServer::GoalHandle active_goal_;
+  bool has_active_goal_;
+
+
 };
 }
 

--- a/ragnar_drivers/include/ragnar_drivers/ragnar_joint_streamer.h
+++ b/ragnar_drivers/include/ragnar_drivers/ragnar_joint_streamer.h
@@ -36,6 +36,7 @@ public:
 
   JointTractoryActionServer action_server_;
   JointTractoryActionServer::GoalHandle active_goal_;
+  trajectory_msgs::JointTrajectoryPoint target_pt_;
   bool has_active_goal_;
 
 

--- a/ragnar_drivers/package.xml
+++ b/ragnar_drivers/package.xml
@@ -47,6 +47,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>industrial_utils</build_depend>
   <build_depend>ragnar_kinematics</build_depend>
+  <build_depend>actionlib</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>simple_message</run_depend>
@@ -54,6 +55,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>industrial_utils</run_depend>
   <run_depend>ragnar_kinematics</run_depend>
+  <run_depend>actionlib</run_depend>
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/ragnar_drivers/src/action_test_node.cpp
+++ b/ragnar_drivers/src/action_test_node.cpp
@@ -1,0 +1,68 @@
+#include <ros/ros.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+#include <actionlib/client/simple_action_client.h>
+
+#include <ragnar_kinematics/ragnar_kinematics.h>
+
+static trajectory_msgs::JointTrajectory makeCircleTrajectory()
+{
+  using namespace trajectory_msgs;
+  // Header
+  JointTrajectory traj;
+
+  // Create circle points
+  const double r = 0.15;
+  const double dt = 0.05;
+
+  double pose[4];
+  double joints[4];
+
+  double total_t = dt;
+
+  for (int i = 0; i < 360; ++i)
+  {
+    pose[0] = r * std::cos(i * M_PI / 180.0);
+    pose[1] = r * std::sin(i * M_PI / 180.0);
+    pose[2] = -0.35;
+    pose[3] = 0.0;
+
+    JointTrajectoryPoint pt;
+    if (!ragnar_kinematics::inverse_kinematics(pose, joints))
+    {
+      ROS_WARN_STREAM("Could not solve for: " << pose[0] << " " << pose[1] << " " << pose[2] << " " << pose[3]);
+    }
+    else
+    {
+      pt.positions.assign(joints, joints+4);
+      pt.time_from_start = ros::Duration(total_t);
+      total_t += dt;
+      traj.points.push_back(pt);
+    }
+  }
+  return traj;
+}
+
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "action_test_node");
+  actionlib::SimpleActionClient<control_msgs::FollowJointTrajectoryAction> ac("joint_trajectory_action", true);
+  ROS_INFO("Waiting");
+  ac.waitForServer();
+  ROS_INFO("Connected");
+
+  control_msgs::FollowJointTrajectoryGoal goal;
+  goal.trajectory = makeCircleTrajectory();
+  goal.trajectory.joint_names.push_back("joint_1");
+  goal.trajectory.joint_names.push_back("joint_2");
+  goal.trajectory.joint_names.push_back("joint_3");
+  goal.trajectory.joint_names.push_back("joint_4");
+
+  goal.trajectory.points.resize(10);
+
+  ac.sendGoal(goal);
+
+  ac.waitForResult();
+
+  return 0;
+}

--- a/ragnar_drivers/src/action_test_node.cpp
+++ b/ragnar_drivers/src/action_test_node.cpp
@@ -11,7 +11,7 @@ static trajectory_msgs::JointTrajectory makeCircleTrajectory()
   JointTrajectory traj;
 
   // Create circle points
-  const double r = 0.15;
+  const double r = 0.2;
   const double dt = 0.05;
 
   double pose[4];
@@ -58,11 +58,13 @@ int main(int argc, char** argv)
   goal.trajectory.joint_names.push_back("joint_3");
   goal.trajectory.joint_names.push_back("joint_4");
 
-  goal.trajectory.points.resize(10);
-
+  ROS_INFO("Sending goal");
   ac.sendGoal(goal);
-
+  ROS_INFO("Waiting on goal");
   ac.waitForResult();
+
+  actionlib::SimpleClientGoalState state = ac.getState();
+  ROS_INFO("Action finished: %s",state.toString().c_str());
 
   return 0;
 }

--- a/ragnar_drivers/src/ragnar_joint_streamer.cpp
+++ b/ragnar_drivers/src/ragnar_joint_streamer.cpp
@@ -17,6 +17,10 @@ namespace TransferStates =
 // Constants
 // NOTE that the robot takes velocity values in millimeters per minute
 const static double RAGNAR_DEFAULT_VELOCITY = 100.0 * 60.0; // 100 mm/s
+// The error from the nominal point that the robot can be at
+// and be considered finished with its goal. It's large, but it seems
+// the FK differs a bit between platforms.
+const static double JOINT_TOL_EPS = 0.05;
 
 // helper function
 static JointTrajPtMessage create_message(int seq,
@@ -243,11 +247,11 @@ void ragnar_drivers::RagnarTrajectoryStreamer::jointStateCB(const sensor_msgs::J
   this->cur_joint_pos_ = *msg;
   if (has_active_goal_)
   {
-    if (state_ == TransferStates::IDLE && inRange(cur_joint_pos_.position, target_pt_.positions, 0.005))
+    if (state_ == TransferStates::IDLE && inRange(cur_joint_pos_.position, target_pt_.positions, JOINT_TOL_EPS))
     {
       ROS_INFO("Action succeeded");
       active_goal_.setSucceeded();
-      has_active_goal_ = true;
+      has_active_goal_ = false;
     }
   }
 }

--- a/ragnar_simulator/CMakeLists.txt
+++ b/ragnar_simulator/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   ragnar_kinematics
   roscpp
   sensor_msgs
+  actionlib
 )
 
 ## System dependencies are found with CMake's conventions

--- a/ragnar_simulator/include/ragnar_simulator/ragnar_simulator.h
+++ b/ragnar_simulator/include/ragnar_simulator/ragnar_simulator.h
@@ -5,6 +5,9 @@
 #include <string>
 
 #include <trajectory_msgs/JointTrajectory.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
+#include <ros/node_handle.h>
+#include <actionlib/server/action_server.h>
 
 namespace ragnar_simulator
 {
@@ -12,7 +15,7 @@ namespace ragnar_simulator
 class RagnarSimulator
 {
 public:
-  RagnarSimulator(const std::vector<double>& seed_pose, const std::vector<std::string>& joint_names);
+  RagnarSimulator(const std::vector<double>& seed_pose, ros::NodeHandle &nh);
 
   const std::vector<std::string>& getJointNames() const { return joint_names_; }
 
@@ -22,8 +25,22 @@ public:
   // trajectory
   bool computeTrajectoryPosition(const ros::Time& tm, std::vector<double>& output) const;
 
+  void pollAction();
+
 private:
+  // Configuration
   std::vector<std::string> joint_names_;
+
+  // Action server
+  typedef actionlib::ActionServer<control_msgs::FollowJointTrajectoryAction> JointTractoryActionServer;
+
+  void goalCB(JointTractoryActionServer::GoalHandle & gh);
+  void cancelCB(JointTractoryActionServer::GoalHandle & gh);
+
+  JointTractoryActionServer action_server_;
+  JointTractoryActionServer::GoalHandle active_goal_;
+  bool has_active_goal_;
+
   // State 
   trajectory_msgs::JointTrajectory traj_;
   std::vector<double> traj_start_position_; 

--- a/ragnar_simulator/package.xml
+++ b/ragnar_simulator/package.xml
@@ -43,10 +43,13 @@
   <build_depend>ragnar_kinematics</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>actionlib</build_depend>
+  
   <run_depend>ragnar_kinematics</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
-
+  <run_depend>actionlib</run_depend>
+  
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/ragnar_simulator/src/ragnar_simulator.cpp
+++ b/ragnar_simulator/src/ragnar_simulator.cpp
@@ -2,14 +2,23 @@
 #include <ros/console.h>
 #include <ros/assert.h>
 
-ragnar_simulator::RagnarSimulator::RagnarSimulator(const std::vector<double>& seed_pose,
-                                                   const std::vector<std::string>& joint_names)
-  : joint_names_(joint_names)
-  , traj_start_position_(seed_pose)
+
+ragnar_simulator::RagnarSimulator::RagnarSimulator(const std::vector<double>& seed_pose, ros::NodeHandle& nh)
+  : traj_start_position_(seed_pose)
   , traj_start_time_(ros::Time::now())
+  , action_server_(nh, "joint_trajectory_action", boost::bind(&RagnarSimulator::goalCB, this, _1),
+                   boost::bind(&RagnarSimulator::cancelCB, this, _1), false)
+  , has_active_goal_(false)
 {
-  ROS_ASSERT(seed_pose.size() == 4);
-  ROS_ASSERT(joint_names.size() == 4);
+  if (traj_start_position_.size() != 4)
+    throw std::runtime_error("Size of Ragnar simulator seed pose != 4");
+
+  joint_names_.push_back("ragnar_joint1");
+  joint_names_.push_back("ragnar_joint2");
+  joint_names_.push_back("ragnar_joint3");
+  joint_names_.push_back("ragnar_joint4");
+
+  action_server_.start();
 }
 
 bool ragnar_simulator::RagnarSimulator::setTrajectory(const trajectory_msgs::JointTrajectory& new_trajectory)
@@ -95,4 +104,44 @@ bool ragnar_simulator::RagnarSimulator::computeTrajectoryPosition(const ros::Tim
 
   output = point;
   return true;
+}
+
+void ragnar_simulator::RagnarSimulator::pollAction()
+{
+  if (has_active_goal_ && ros::Time::now() > (traj_start_time_ + traj_.points.back().time_from_start))
+  {
+    active_goal_.setSucceeded();
+    has_active_goal_ = false;
+  }
+}
+
+void ragnar_simulator::RagnarSimulator::goalCB(JointTractoryActionServer::GoalHandle& gh)
+{
+  ROS_INFO("Recieved new goal request");
+  if (has_active_goal_)
+  {
+    ROS_WARN("Received new goal, canceling current one");
+    active_goal_.setAborted();
+    has_active_goal_ = false;
+  }
+
+  gh.setAccepted();
+  active_goal_ = gh;
+  has_active_goal_ = true;
+
+  const trajectory_msgs::JointTrajectory& traj = active_goal_.getGoal()->trajectory;
+  setTrajectory(traj);
+}
+
+void ragnar_simulator::RagnarSimulator::cancelCB(JointTractoryActionServer::GoalHandle &gh)
+{
+  ROS_INFO("Cancelling goal");
+  if (active_goal_ == gh)
+  {
+    // stop the controller
+    traj_start_time_ = ros::Time(0);
+    // mark the goal as canceled
+    active_goal_.setCanceled();
+    has_active_goal_ = false;
+  }
 }

--- a/ragnar_simulator/src/ragnar_simulator_node.cpp
+++ b/ragnar_simulator/src/ragnar_simulator_node.cpp
@@ -6,7 +6,7 @@
 
 void publishCurrentState(const ros::TimerEvent& timer,
                          ros::Publisher& pub,
-                         const ragnar_simulator::RagnarSimulator& sim)
+                         ragnar_simulator::RagnarSimulator& sim)
 {
   sensor_msgs::JointState joint_state;
   joint_state.header.frame_id = "world";
@@ -14,6 +14,7 @@ void publishCurrentState(const ros::TimerEvent& timer,
   joint_state.name = sim.getJointNames();
   // compute current position
   sim.computeTrajectoryPosition(timer.current_real, joint_state.position);
+  sim.pollAction();
 
   pub.publish(joint_state);
 }
@@ -55,7 +56,7 @@ int main(int argc, char** argv)
   pnh.param<double>("rate", publish_rate, 30.0);
   
   // instantiate simulation
-  ragnar_simulator::RagnarSimulator sim (seed_position, joint_names);
+  ragnar_simulator::RagnarSimulator sim (seed_position, nh);
 
   // create pub/subscribers and wire them up
   ros::Publisher current_state_pub = nh.advertise<sensor_msgs::JointState>("joint_states", 1);
@@ -69,7 +70,7 @@ int main(int argc, char** argv)
       nh.createTimer(ros::Duration(1.0/publish_rate), boost::bind(publishCurrentState,
                                                      _1,
                                                      boost::ref(current_state_pub),
-                                                     boost::cref(sim)));
+                                                     boost::ref(sim)));
 
   ROS_INFO("Simulator service spinning");
   ros::spin();


### PR DESCRIPTION
This PR addresses issue #4. It creates a `FollowJointTrajectory` action client in both the simulator and actual-robot-streaming-client on the name `joint_trajectory_action`. See example of its use in ` ragnar_drivers/src/action_test_node.cpp`. 

Does NOT currently include a timeout or watchdog, which it probably should.