### PR TITLE
Joint Name Cleanup

### DIFF
--- a/ragnar_drivers/include/ragnar_drivers/ragnar_joint_feedback_message.h
+++ b/ragnar_drivers/include/ragnar_drivers/ragnar_joint_feedback_message.h
@@ -20,7 +20,7 @@ class RagnarJointFeedbackHandler
 {
 
 public:
-  RagnarJointFeedbackHandler();
+  RagnarJointFeedbackHandler(const std::vector<std::string>& joint_names);
   ~RagnarJointFeedbackHandler() {}
 
   using industrial::message_handler::MessageHandler::init;
@@ -40,6 +40,7 @@ public:
 private:
   ros::NodeHandle nh_;
   ros::Publisher joint_states_pub_;
+  std::vector<std::string> joint_names_;
 };
 }
 

--- a/ragnar_drivers/launch/ragnar_state_listener.launch
+++ b/ragnar_drivers/launch/ragnar_state_listener.launch
@@ -3,12 +3,14 @@
   <arg name="robot_ip" default="192.168.1.240"/>
   <arg name="port" default="11002"/>
 
-  <node name="ragnar_drivers" pkg="ragnar_drivers" type="ragnar_client_node" >
+  <rosparam command="load" file="$(find ragnar_drivers)/config/ragnar_joint_names.yaml" />
+
+  <node name="ragnar_drivers" pkg="ragnar_drivers" type="ragnar_client_node">
     <param name="ip" value="$(arg robot_ip)"/>
     <param name="port" value="$(arg port)"/>
   </node>
 
   <!-- Ragnar State Publisher -->
-  <node name="ragnar_state_publisher" pkg="ragnar_state_publisher" type="ragnar_state_publisher_node" />
+  <node name="ragnar_state_publisher" pkg="ragnar_state_publisher" type="ragnar_state_publisher_node"/>
   
 </launch>

--- a/ragnar_drivers/launch/ragnar_state_listener.launch
+++ b/ragnar_drivers/launch/ragnar_state_listener.launch
@@ -11,6 +11,9 @@
   </node>
 
   <!-- Ragnar State Publisher -->
-  <node name="ragnar_state_publisher" pkg="ragnar_state_publisher" type="ragnar_state_publisher_node"/>
+  <node name="ragnar_state_publisher" pkg="ragnar_state_publisher" type="ragnar_state_publisher_node">
+    <!-- Prefix given to ragnar macro/xacro in URDF (defaults empty) -->
+    <param name="prefix" value=""/> 
+  </node>
   
 </launch>

--- a/ragnar_drivers/src/ragnar_client.cpp
+++ b/ragnar_drivers/src/ragnar_client.cpp
@@ -25,13 +25,15 @@ int main(int argc, char** argv)
 
   RobotStateInterface client;
 
-  ragnar_drivers::RagnarJointFeedbackHandler feedback_handler;
-  feedback_handler.setNodeHandle(nh);
 
   if (!ip_addr.empty())
   {
     // make socket connection
     client.init(ip_addr, tcp_port);
+
+    // Create a message handler
+    ragnar_drivers::RagnarJointFeedbackHandler feedback_handler (client.get_joint_names());
+    feedback_handler.setNodeHandle(nh);
 
     // add message handler to manager
     feedback_handler.setCBConnection(client.get_connection());
@@ -44,7 +46,7 @@ int main(int argc, char** argv)
   }
   else
   {
-    ROS_WARN(
+    ROS_FATAL(
         "Ragnar feedback interface requires that the 'ip' parameter be set");
   }
 

--- a/ragnar_drivers/src/ragnar_joint_feedback_message.cpp
+++ b/ragnar_drivers/src/ragnar_joint_feedback_message.cpp
@@ -7,18 +7,11 @@ namespace ragnar_drivers
 {
 using namespace industrial;
 
-// Add Joint Names
-static void addJointNames(sensor_msgs::JointState& msg)
-{
-  msg.name.push_back("ragnar_joint1");
-  msg.name.push_back("ragnar_joint2");
-  msg.name.push_back("ragnar_joint3");
-  msg.name.push_back("ragnar_joint4");
-}
-
 // Message handler
-RagnarJointFeedbackHandler::RagnarJointFeedbackHandler()
+RagnarJointFeedbackHandler::RagnarJointFeedbackHandler(const std::vector<std::string> &joint_names)
+  : joint_names_(joint_names)
 {
+  ROS_ASSERT(joint_names.size() == 4);
   joint_states_pub_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 1);
 }
 
@@ -29,7 +22,7 @@ bool RagnarJointFeedbackHandler::internalCB(simple_message::SimpleMessage& in)
   msg.header.stamp = ros::Time::now();
   msg.header.frame_id = "base_link";
 
-  addJointNames(msg);
+  msg.name = joint_names_;
 
   joint_feedback_message::JointFeedbackMessage joint_msg;
   joint_msg.init(in);

--- a/ragnar_simulator/include/ragnar_simulator/ragnar_simulator.h
+++ b/ragnar_simulator/include/ragnar_simulator/ragnar_simulator.h
@@ -12,7 +12,7 @@ namespace ragnar_simulator
 class RagnarSimulator
 {
 public:
-  RagnarSimulator(const std::vector<double>& seed_pose);
+  RagnarSimulator(const std::vector<double>& seed_pose, const std::vector<std::string>& joint_names);
 
   const std::vector<std::string>& getJointNames() const { return joint_names_; }
 

--- a/ragnar_simulator/src/ragnar_simulator.cpp
+++ b/ragnar_simulator/src/ragnar_simulator.cpp
@@ -1,17 +1,15 @@
 #include "ragnar_simulator/ragnar_simulator.h"
 #include <ros/console.h>
+#include <ros/assert.h>
 
-ragnar_simulator::RagnarSimulator::RagnarSimulator(const std::vector<double>& seed_pose)
-  : traj_start_position_(seed_pose)
+ragnar_simulator::RagnarSimulator::RagnarSimulator(const std::vector<double>& seed_pose,
+                                                   const std::vector<std::string>& joint_names)
+  : joint_names_(joint_names)
+  , traj_start_position_(seed_pose)
   , traj_start_time_(ros::Time::now())
 {
-  if (traj_start_position_.size() != 4)
-    throw std::runtime_error("Size of Ragnar simulator seed pose != 4");
-
-  joint_names_.push_back("ragnar_joint1");
-  joint_names_.push_back("ragnar_joint2");
-  joint_names_.push_back("ragnar_joint3");
-  joint_names_.push_back("ragnar_joint4");
+  ROS_ASSERT(seed_pose.size() == 4);
+  ROS_ASSERT(joint_names.size() == 4);
 }
 
 bool ragnar_simulator::RagnarSimulator::setTrajectory(const trajectory_msgs::JointTrajectory& new_trajectory)

--- a/ragnar_simulator/src/ragnar_simulator_node.cpp
+++ b/ragnar_simulator/src/ragnar_simulator_node.cpp
@@ -34,6 +34,16 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
   ros::NodeHandle pnh ("~");
 
+  // nh loads joint names if possible
+  std::vector<std::string> joint_names;
+  if (!nh.getParam("controller_joint_names", joint_names))
+  {
+    // otherwise, it loads defaults
+    joint_names.push_back("joint_1");
+    joint_names.push_back("joint_2");
+    joint_names.push_back("joint_3");
+    joint_names.push_back("joint_4");
+  }
   // pnh loads configuration parameters
   std::vector<double> seed_position;
   if (!pnh.getParam("initial_position", seed_position))
@@ -45,7 +55,7 @@ int main(int argc, char** argv)
   pnh.param<double>("rate", publish_rate, 30.0);
   
   // instantiate simulation
-  ragnar_simulator::RagnarSimulator sim (seed_position);
+  ragnar_simulator::RagnarSimulator sim (seed_position, joint_names);
 
   // create pub/subscribers and wire them up
   ros::Publisher current_state_pub = nh.advertise<sensor_msgs::JointState>("joint_states", 1);

--- a/ragnar_state_publisher/include/ragnar_state_publisher/ragnar_state_publisher.h
+++ b/ragnar_state_publisher/include/ragnar_state_publisher/ragnar_state_publisher.h
@@ -14,9 +14,14 @@ namespace ragnar_state_publisher
 class RagnarStatePublisher
 {
 public:
-  RagnarStatePublisher(const std::string& joints_topic, const std::string& prefix = "");
+  RagnarStatePublisher(const std::string& joints_topic,
+                       const std::vector<std::string>& joint_names,
+                       const std::string& prefix = "");
 
   void updateJointPosition(const sensor_msgs::JointStateConstPtr& joints);
+
+protected:
+  bool extractJoints(const sensor_msgs::JointState& msg, double* actuators) const;
 
 private:
   ros::NodeHandle nh_;
@@ -25,6 +30,8 @@ private:
 
   tf::Transform base_transform_;
   std::vector<tf::Vector3> zi_;
+
+  std::vector<std::string> joint_names_;
   std::string prefix_;
 };
 

--- a/ragnar_state_publisher/src/ragnar_state_publisher_node.cpp
+++ b/ragnar_state_publisher/src/ragnar_state_publisher_node.cpp
@@ -17,7 +17,7 @@ static std::vector<std::string> getDefaultRagnarJointNames()
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "ragnar_state_publisher");
-  ros::NodeHandle nh;
+  ros::NodeHandle nh, pnh("~");
 
   std::vector<std::string> joint_names;
   if (!nh.getParam("controller_joint_names", joint_names))
@@ -30,7 +30,14 @@ int main(int argc, char** argv)
     ROS_INFO("Ragnar State Publisher: loaded joint names from param server");
   }
 
-  ragnar_state_publisher::RagnarStatePublisher pub ("joint_states", joint_names);
+  std::string prefix;
+  pnh.param<std::string>("prefix", prefix, "");
+  if (!prefix.empty())
+  {
+    ROS_INFO("Ragnar State Publisher: Using prefix '%s'", prefix.c_str());
+  }
+
+  ragnar_state_publisher::RagnarStatePublisher pub ("joint_states", joint_names, prefix);
 
   ros::spin();
 }

--- a/ragnar_state_publisher/src/ragnar_state_publisher_node.cpp
+++ b/ragnar_state_publisher/src/ragnar_state_publisher_node.cpp
@@ -2,11 +2,35 @@
 
 #include "ragnar_state_publisher/ragnar_state_publisher.h"
 
+
+static std::vector<std::string> getDefaultRagnarJointNames()
+{
+  std::vector<std::string> names;
+  names.reserve(4);
+  names.push_back("joint_1");
+  names.push_back("joint_2");
+  names.push_back("joint_3");
+  names.push_back("joint_4");
+  return names;
+}
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "ragnar_state_publisher");
+  ros::NodeHandle nh;
 
-  ragnar_state_publisher::RagnarStatePublisher pub ("joint_states");
+  std::vector<std::string> joint_names;
+  if (!nh.getParam("controller_joint_names", joint_names))
+  {
+    joint_names = getDefaultRagnarJointNames();
+    ROS_INFO("Ragnar State Publisher: loading default joint names [joint_1 ... joint_4]");
+  }
+  else
+  {
+    ROS_INFO("Ragnar State Publisher: loaded joint names from param server");
+  }
+
+  ragnar_state_publisher::RagnarStatePublisher pub ("joint_states", joint_names);
 
   ros::spin();
 }

--- a/ragnar_support/urdf/ragnar.xacro
+++ b/ragnar_support/urdf/ragnar.xacro
@@ -1,74 +1,15 @@
 <?xml version="1.0" ?>
 <robot name="Ragnar" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:include filename="$(find ragnar_support)/urdf/ragnar_upper2_macro.xacro"/>
+  <xacro:include filename="$(find ragnar_support)/urdf/ragnar_macro.xacro"/>
   
   <link name="world"/>
+
+  <xacro:ragnar prefix=""/>
 
   <joint name="world_to_ragnar" type="fixed">
     <parent link="world"/>
     <child link="base_link"/>
     <origin xyz="0 0 0" />
   </joint>
-
-  <link name="base_link"/>
-
-  <link name="base_link2">
-    <inertial>
-      <origin xyz="-4.80572213006859E-06 9.64495107789746E-06 -0.0184680705713898" rpy="0 0 0" />
-      <mass value="26.5217124601092" />
-      <inertia ixx="0.936457909215975" ixy="-0.00108838510526368" ixz="1.58187182756307E-06"
-        iyy="1.50216890338436" iyz="1.0107984651762E-05" izz="2.28323593907717" />
-    </inertial>
-    <visual>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <mesh filename="package://ragnar_support/meshes/base_link.STL" />
-      </geometry>
-      <material name="">
-        <color rgba="0.5 0.5 0.5 1" />
-      </material>
-    </visual>
-    <collision>
-      <origin xyz="0 0 0" rpy="0 0 0" />
-      <geometry>
-        <mesh filename="package://ragnar_support/meshes/base_link.STL" />
-      </geometry>
-    </collision>
-  </link>
-
- <joint name="base_rotate" type="floating">
-    <origin xyz="0 0 0.05" rpy="0 0 1.57" />
-    <parent link="base_link" />
-    <child link="base_link2" />
-    <axis xyz="0 0 0" />
-  </joint>
-
-  <xacro:ragnar_upper2 num="1" x="0.122" y="0.249" z="-0.0877" r="-0.577" p="-0.783" w="-1.311" d1="0.300" d2="0.550"/>
-  <xacro:ragnar_upper2 num="2" x="-0.122" y="0.249" z="-0.0877" r="-2.698" p="-0.788" w="-1.834" d1="0.300" d2="0.550"/>
-  <xacro:ragnar_upper2 num="3" x="-0.122" y="-0.249" z="-0.0877" r="-0.456" p="-0.783" w="1.831" d1="0.300" d2="0.550"/>
-  <xacro:ragnar_upper2 num="4" x="0.122" y="-0.249" z="-0.0877" r="-2.531" p="-0.788" w="1.307" d1="0.300" d2="0.550"/>
-
-
-  <link name="ee_link">
-    <visual>
-      <origin xyz="0 0 0" rpy="1.57 0 1.57" />
-      <geometry>
-        <mesh filename="package://ragnar_support/meshes/ragnar_ee.STL" />
-      </geometry>
-      <material name="">
-        <color rgba="1 0 0 1" />
-      </material>
-    </visual>
-    <collision>
-      <origin xyz="0 0 0" rpy="1.57 0 1.57" />
-      <geometry>
-        <mesh filename="package://ragnar_support/meshes/ragnar_ee.STL" />
-      </geometry>
-    </collision>
-  </link>
-  <joint name="ee_joint" type="floating">
-    <origin xyz="0 0 0" rpy="0 0 0" />
-    <parent link="lower_arm_1" />
-    <child link="ee_link" />
-  </joint>
+  
 </robot>

--- a/ragnar_support/urdf/ragnar_macro.xacro
+++ b/ragnar_support/urdf/ragnar_macro.xacro
@@ -1,0 +1,77 @@
+<?xml version="1.0" ?>
+<robot name="Ragnar" xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:include filename="$(find ragnar_support)/urdf/ragnar_upper2_macro.xacro"/>
+
+  <xacro:macro name="ragnar" params="prefix">
+
+    <!-- Base Link -->
+    <link name="${prefix}base_link"/>
+    <link name="${prefix}base_link2">
+      <inertial>
+        <origin xyz="-4.80572213006859E-06 9.64495107789746E-06 -0.0184680705713898" rpy="0 0 0" />
+        <mass value="26.5217124601092" />
+        <inertia ixx="0.936457909215975" ixy="-0.00108838510526368" ixz="1.58187182756307E-06"
+          iyy="1.50216890338436" iyz="1.0107984651762E-05" izz="2.28323593907717" />
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <mesh filename="package://ragnar_support/meshes/base_link.STL" />
+        </geometry>
+        <material name="">
+          <color rgba="0.5 0.5 0.5 1" />
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <mesh filename="package://ragnar_support/meshes/base_link.STL" />
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="${prefix}base_rotate" type="floating">
+      <origin xyz="0 0 0.05" rpy="0 0 1.5708" />
+      <parent link="${prefix}base_link" />
+      <child link="${prefix}base_link2" />
+      <axis xyz="0 0 0" />
+    </joint>
+
+    <!-- The four ragnar arms -->
+    <xacro:ragnar_upper2 prefix="${prefix}" num="1" x="0.122" y="0.249" z="-0.0877" r="-0.577" p="-0.783" w="-1.311" d1="0.300" d2="0.550"/>
+    <xacro:ragnar_upper2 prefix="${prefix}" num="2" x="-0.122" y="0.249" z="-0.0877" r="-2.698" p="-0.788" w="-1.834" d1="0.300" d2="0.550"/>
+    <xacro:ragnar_upper2 prefix="${prefix}" num="3" x="-0.122" y="-0.249" z="-0.0877" r="-0.456" p="-0.783" w="1.831" d1="0.300" d2="0.550"/>
+    <xacro:ragnar_upper2 prefix="${prefix}" num="4" x="0.122" y="-0.249" z="-0.0877" r="-2.531" p="-0.788" w="1.307" d1="0.300" d2="0.550"/>
+
+    <!-- End Effector Link -->
+    <link name="${prefix}ee_link">
+      <visual>
+        <origin xyz="0 0 0" rpy="1.57 0 1.57" />
+        <geometry>
+          <mesh filename="package://ragnar_support/meshes/ragnar_ee.STL" />
+        </geometry>
+        <material name="">
+          <color rgba="1 0 0 1" />
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="1.57 0 1.57" />
+        <geometry>
+          <mesh filename="package://ragnar_support/meshes/ragnar_ee.STL" />
+        </geometry>
+      </collision>
+    </link>
+    <joint name="${prefix}ee_joint" type="floating">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="${prefix}lower_arm_1" />
+      <child link="${prefix}ee_link" />
+    </joint>
+
+    <!-- Tool0 for compliance with ROS-I protocols -->
+    <link name="${prefix}tool0"/>
+    <joint name="${prefix}ee_link_to_tool0" type="fixed">
+      <parent link="${prefix}ee_link"/>
+      <child link="${prefix}tool0"/>
+    </joint>
+  </xacro:macro>
+</robot>

--- a/ragnar_support/urdf/ragnar_upper2_macro.xacro
+++ b/ragnar_support/urdf/ragnar_upper2_macro.xacro
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <robot name="ragnar" xmlns:xacro="http://ros.org/wiki/xacro">
-  <xacro:macro name="ragnar_upper2" params="num x y z r p w d1 d2"> 
+  <xacro:macro name="ragnar_upper2" params=" prefix num x y z r p w d1 d2"> 
     
-  <link name="upper_arm_${num}">
+  <link name="${prefix}upper_arm_${num}">
     <visual>
       <origin xyz="0 0 0" rpy="0 1.57 0" />
       <geometry>
@@ -42,10 +42,10 @@
     </collision>
   </link>
 
-  <joint name="a${num}_j1" type="revolute">
+  <joint name="${prefix}joint_${num}" type="floating">
     <origin xyz="${x} ${y} ${z}" rpy="${r} ${p} ${w}" />
-    <parent link="base_link2" />
-    <child link="upper_arm_${num}" />
+    <parent link="${prefix}base_link2" />
+    <child link="${prefix}upper_arm_${num}" />
     <axis xyz="-1.0 0 0" />
     <limit effort="0" lower="-3.1416" upper="3.1416" velocity="2.618"/>
   </joint>
@@ -53,7 +53,7 @@
     <!--xacro:include filename="$(find ragnar_support)/urdf/Ragnar_lower_macro.xacro"/>
     <xacro:ragnar_lower prefix=""/-->
 
-  <link name="lower_arm_${num}">
+  <link name="${prefix}lower_arm_${num}">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>
@@ -102,10 +102,10 @@
     </collision>
   </link>
 
-  <joint name="a${num}_j2" type="floating">
+  <joint name="${prefix}a${num}_j2" type="floating">
     <origin xyz="0 ${d1} 0" rpy="0 0 0" />
-    <parent link="upper_arm_${num}" />
-    <child link="lower_arm_${num}" />
+    <parent link="${prefix}upper_arm_${num}" />
+    <child link="${prefix}lower_arm_${num}" />
   </joint>
 
 


### PR DESCRIPTION
This PR (related to #6 and #2) makes the joint names consistent across nodes and allows for the use of robot_state_publisher and joint_state_publisher along side their ragnar specializations. Names are read through the `controller_joint_names` parameter.

I imagine their will be usability issues that come up as people create more complicated work cells. I'll open issues as I become aware of problems.