### PR TITLE
Fix catkin make

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ ROS Ragnar depends on the following core packages:
 
 **Please note that you will need the most recent versions of the debians for 'robot_state_publisher' as of 24 Nov, 2015. Please 'apt-get update' if you have not**
 
+**Please note that you will need an RViz version > 1.11.8**
+
 ## Simulation
 If you want to simulate the robot:
 ```

--- a/ragnar_drivers/CMakeLists.txt
+++ b/ragnar_drivers/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED
     rospy
     sensor_msgs
     industrial_utils
+    industrial_robot_client
     ragnar_kinematics
     actionlib
 )


### PR DESCRIPTION
There was a missing package in the `find_package` entry of **ragnar_drivers/CMakeLists.txt** preventing the package from compiling
added a slight modification to README.md, concerning the version requirements for Rviz

Error message:
```
/workspaces/Rangar_rob/src/ROSRagnarEDU/ragnar_drivers/src/ragnar_client.cpp:6:59: fatal error: industrial_robot_client/robot_state_interface.h: No such file or directory
 #include <industrial_robot_client/robot_state_interface.h>
                                                           ^
compilation terminated.
```
